### PR TITLE
JENKINS-16869: Exception when clicking on timestamper link

### DIFF
--- a/src/main/java/configurationslicing/maven/MavenGoals.java
+++ b/src/main/java/configurationslicing/maven/MavenGoals.java
@@ -17,6 +17,12 @@ public class MavenGoals extends UnorderedStringSlicer<MavenModuleSet> {
         super(new MavenGoalsSlicerSpec());
     }
     
+    @Override
+    public void loadPluginDependencyClass() {
+        // this is just to demonstrate that the Maven plugin is loaded
+        MavenModuleSet.class.getClass();
+    }
+    
     public static class MavenGoalsSlicerSpec extends UnorderedStringSlicerSpec<MavenModuleSet> {
         private static final String DEFAULT = "(Default)";
 

--- a/src/main/java/configurationslicing/maven/MavenOptsSlicer.java
+++ b/src/main/java/configurationslicing/maven/MavenOptsSlicer.java
@@ -7,7 +7,6 @@ import hudson.model.Hudson;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import configurationslicing.UnorderedStringSlicer;
 
@@ -16,6 +15,12 @@ public class MavenOptsSlicer extends UnorderedStringSlicer<MavenModuleSet> {
 
     public MavenOptsSlicer() {
         super(new MavenOptsSlicerSpec());
+    }
+    
+    @Override
+    public void loadPluginDependencyClass() {
+        // this is just to demonstrate that the Maven plugin is loaded
+        MavenModuleSet.class.getClass();
     }
     
     public static class MavenOptsSlicerSpec extends UnorderedStringSlicerSpec<MavenModuleSet> {

--- a/src/main/java/configurationslicing/prioritysorter/PrioritySorterSlicer.java
+++ b/src/main/java/configurationslicing/prioritysorter/PrioritySorterSlicer.java
@@ -19,6 +19,12 @@ public class PrioritySorterSlicer extends UnorderedStringSlicer<Job<?,?>>{
     public PrioritySorterSlicer() {
         super(new PrioritySorterSliceSpec());
     }
+    
+    @Override
+    public void loadPluginDependencyClass() {
+        // this is just to demonstrate that the PrioritySorter plugin is loaded
+        PrioritySorterJobProperty.class.getClass();
+    }
 
     public static class PrioritySorterSliceSpec extends UnorderedStringSlicerSpec<Job<?,?>> {
 

--- a/src/main/java/configurationslicing/timestamper/TimestamperSlicer.java
+++ b/src/main/java/configurationslicing/timestamper/TimestamperSlicer.java
@@ -22,6 +22,12 @@ public class TimestamperSlicer extends UnorderedStringSlicer<AbstractProject<?,?
         super(new TimestamperSliceSpec());
     }
 
+    @Override
+    public void loadPluginDependencyClass() {
+        // this is just to demonstrate that the Timestamper plugin is loaded
+        TimestamperBuildWrapper.class.getClass();
+    }
+    
     public static class TimestamperSliceSpec extends UnorderedStringSlicerSpec<AbstractProject<?,?>> {
 
         private static final String DISABLED = Boolean.FALSE.toString();


### PR DESCRIPTION
you can see the timestamper configuration slicer even when the timestamper plugin is not installed, which gives you this error (though this is not the problem reported as such). I've made a change so that the button is not enabled if the plugin is not
available.
