### PR TITLE
[FIXED JENKINS-21445] Boolean slicer does not check to see if property already set.

### DIFF
--- a/src/main/java/configurationslicing/BooleanSlice.java
+++ b/src/main/java/configurationslicing/BooleanSlice.java
@@ -35,6 +35,10 @@ public class BooleanSlice<I> extends Slice {
         nameToValue.put(name, value);
     }
 
+    public boolean exists(String name) {
+      return nameToValue.get(name) != null;
+    }
+
     public boolean get(String name) {
         Boolean object = nameToValue.get(name);
         if (object == null) {

--- a/src/main/java/configurationslicing/BooleanSlicer.java
+++ b/src/main/java/configurationslicing/BooleanSlicer.java
@@ -33,7 +33,11 @@ public class BooleanSlicer<I> implements Slicer<BooleanSlice<I>, I>{
     }
 
     public boolean transform(BooleanSlice<I> t, I i) {
+      if (t.exists(spec.getName(i))) {
         return spec.setValue(i, t.get(spec.getName(i)));
+      } else {
+        return false;
+      }
     }
 
     public String getName() {


### PR DESCRIPTION
The boolean slicer would change the value of unmodified configurations to false when using the `configuration by view` option.
