### PR TITLE
Use factory method instead

### DIFF
--- a/src/main/java/configurationslicing/email/ExtEmailSlicer.java
+++ b/src/main/java/configurationslicing/email/ExtEmailSlicer.java
@@ -78,7 +78,7 @@ public class ExtEmailSlicer extends	UnorderedStringSlicer<AbstractProject<?, ?>>
 			if (mailer == null) {
 				DescribableList<Publisher,Descriptor<Publisher>> publishers = project.getPublishersList();
 				ExtendedEmailPublisher publisher = new ExtendedEmailPublisher();
-				FailureTrigger trigger = new FailureTrigger();
+				FailureTrigger trigger = FailureTrigger.createDefault();
 				EmailType email = new EmailType();
 				email.setSendToDevelopers(true);
 				email.setSendToRecipientList(true);


### PR DESCRIPTION
The empty constructor does not exist in current version of emailext [1].

As suggested in [2].

[1]https://github.com/jenkinsci/email-ext-plugin/commit/fb5e4581b60d0bd6391941bb908476fc93556e89#diff-6fe022ea34bc1c9ae28950052efbf52cL15
[2] https://issues.jenkins-ci.org/browse/JENKINS-21225?focusedCommentId=216966&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-216966

Note that this change is a rough suggestion/starting point. I haven't tested the code.