### PR TITLE
Fix for JENKINS-20319

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,9 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>org.jvnet.hudson.plugins</groupId>
+			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>email-ext</artifactId>
-			<version>2.7</version>
-			<scope>compile</scope>
+			<version>2.29</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.424.6</version>
+		<version>1.509.2</version>
 	</parent>
 	<artifactId>configurationslicing</artifactId>
 	<packaging>hpi</packaging>

--- a/src/main/java/configurationslicing/email/AbstractEmailSliceSpec.java
+++ b/src/main/java/configurationslicing/email/AbstractEmailSliceSpec.java
@@ -16,6 +16,7 @@ import configurationslicing.UnorderedStringSlicer.UnorderedStringSlicerSpec;
 public abstract class AbstractEmailSliceSpec extends UnorderedStringSlicerSpec<AbstractProject<?, ?>> {
 
 	public static final String DISABLED = "(Disabled)";
+	private static final String EMPTY = "";
 
 	private String joinString;
 	private String name;
@@ -32,7 +33,12 @@ public abstract class AbstractEmailSliceSpec extends UnorderedStringSlicerSpec<A
 		String recipients = handler.getRecipients(project);
 		recipients = normalize(recipients, "\n");
 		if (recipients == null) {
-			recipients = DISABLED;
+			if (handler.sendToIndividuals(project)) {
+				recipients = EMPTY;
+			}
+			else {
+				recipients = DISABLED;
+			}
 		}
 		List<String> values = new ArrayList<String>();
 		values.add(recipients);
@@ -41,8 +47,8 @@ public abstract class AbstractEmailSliceSpec extends UnorderedStringSlicerSpec<A
 	public boolean setValues(AbstractProject<?, ?> project, List<String> set) {
 		String newEmail = join(set);
 		
-		// if no email is present, we're going to assume that's the same as disabled
-		boolean disabled = (DISABLED.equals(newEmail) || newEmail == null);
+		// only regard explicit (disabled) [regardless of case]
+		boolean disabled = (newEmail == null) ? false : (DISABLED.toLowerCase().equals(newEmail.toLowerCase()));		
 		boolean saved = false;
 		ProjectHandler handler = getProjectHandler(project);
 

--- a/src/main/java/configurationslicing/email/CoreEmailSlicer.java
+++ b/src/main/java/configurationslicing/email/CoreEmailSlicer.java
@@ -86,6 +86,15 @@ public class CoreEmailSlicer extends
 				return false;
 			}
 		}
+		public boolean sendToIndividuals(AbstractProject project) {
+			Mailer mailer = getMailer(project);
+			if (mailer != null) {
+				return mailer.sendToIndividuals;
+			}
+			else {
+				return false;
+			}
+		}
 	}
 	@SuppressWarnings("unchecked")
 	private static class MavenEmailProjectHandler implements ProjectHandler {
@@ -136,6 +145,16 @@ public class CoreEmailSlicer extends
 				return false;
 			}
 		}
+		public boolean sendToIndividuals(AbstractProject project) {
+			MavenMailer mailer = getMailer(project);
+			if (mailer != null) {
+				return mailer.sendToIndividuals;
+			}
+			else {
+				return false;
+			}
+		}
+		
 	}
 	
 }

--- a/src/main/java/configurationslicing/email/ExtEmailSlicer.java
+++ b/src/main/java/configurationslicing/email/ExtEmailSlicer.java
@@ -105,6 +105,13 @@ public class ExtEmailSlicer extends	UnorderedStringSlicer<AbstractProject<?, ?>>
 				return false;
 			}
 		}
+		
+		/**
+		* not yet implemented for ExtendedEmailPublisher
+		*/
+		public boolean sendToIndividuals(AbstractProject project) {
+			return false;
+		}
 	}
 	
 }

--- a/src/main/java/configurationslicing/email/ExtEmailSlicer.java
+++ b/src/main/java/configurationslicing/email/ExtEmailSlicer.java
@@ -6,12 +6,15 @@ import hudson.model.Descriptor;
 import hudson.model.Hudson;
 import hudson.plugins.emailext.EmailType;
 import hudson.plugins.emailext.ExtendedEmailPublisher;
+import hudson.plugins.emailext.plugins.EmailTrigger;
+import hudson.plugins.emailext.plugins.EmailTriggerDescriptor;
 import hudson.plugins.emailext.plugins.trigger.FailureTrigger;
 import hudson.tasks.Publisher;
 import hudson.util.DescribableList;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
@@ -109,8 +112,18 @@ public class ExtEmailSlicer extends	UnorderedStringSlicer<AbstractProject<?, ?>>
 		/**
 		* not yet implemented for ExtendedEmailPublisher
 		*/
-		public boolean sendToIndividuals(AbstractProject project) {
-			return false;
+		public boolean sendToIndividuals(AbstractProject project) {			
+			boolean result = false;
+			ExtendedEmailPublisher mailer = getMailer(project);
+			if (mailer != null) {
+				for (EmailTrigger trigger : mailer.getConfiguredTriggers()) {
+					if (trigger.getEmail().getSendToDevelopers()) {
+						result = true;
+						break;
+					}
+				}
+			}
+			return result;
 		}
 	}
 	

--- a/src/main/java/configurationslicing/email/ProjectHandler.java
+++ b/src/main/java/configurationslicing/email/ProjectHandler.java
@@ -11,5 +11,5 @@ public interface ProjectHandler {
 	boolean removeMailer(AbstractProject project) throws IOException;
 	boolean addMailer(AbstractProject project) throws IOException;
 	boolean setRecipients(AbstractProject project, String recipients) throws IOException;
-
+	boolean sendToIndividuals(AbstractProject project);
 }

--- a/src/test/java/configurationslicing/EmailSlicerTest.java
+++ b/src/test/java/configurationslicing/EmailSlicerTest.java
@@ -7,6 +7,9 @@ import hudson.maven.reporters.MavenMailer;
 import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
 import hudson.model.FreeStyleProject;
+import hudson.plugins.emailext.EmailType;
+import hudson.plugins.emailext.ExtendedEmailPublisher;
+import hudson.plugins.emailext.plugins.trigger.FailureTrigger;
 import hudson.tasks.Publisher;
 import hudson.tasks.Mailer;
 import hudson.util.DescribableList;
@@ -33,7 +36,7 @@ public class EmailSlicerTest extends HudsonTestCase {
 	 *  <li>return the set list of recipients (like "john@doe.com sue@gov.com") otherwise</li>
 	 * @throws Exception
 	 */
-	public void testSendToIndividualsWithCoreMailer() throws Exception {
+	public void testSendToIndividuals() throws Exception {
 		assertEquals("Setting empty recipients with sendToIndividuals enabled", null, setAndGetCoreValues(createMavenProjectWithSendToIndividualsAndEmptyRecipients(), null));
 		assertEquals("Setting >(disabled)< with sendToIndividuals enabled", "(Disabled)", setAndGetCoreValues(createMavenProjectWithSendToIndividualsAndEmptyRecipients(), "(disabled)"));
 		assertEquals("Setting >(DISABLED)< with sendToIndividuals enabled", "(Disabled)", setAndGetCoreValues(createMavenProjectWithSendToIndividualsAndEmptyRecipients(), "(DISABLED)"));
@@ -43,6 +46,9 @@ public class EmailSlicerTest extends HudsonTestCase {
 		assertEquals("Setting >(disabled)< with sendToIndividuals enabled", "(Disabled)", setAndGetCoreValues(createFreestyleProjectWithSendToIndividualsAndEmptyRecipients(), "(disabled)"));
 		assertEquals("Setting >(DISABLED)< with sendToIndividuals enabled", "(Disabled)", setAndGetCoreValues(createFreestyleProjectWithSendToIndividualsAndEmptyRecipients(), "(DISABLED)"));
 		assertEquals("Setting recipients with sendToIndividuals enabled", "john@doe.com sue@gov.com", setAndGetCoreValues(createFreestyleProjectWithSendToIndividualsAndEmptyRecipients(), "john@doe.com sue@gov.com"));
+		
+		assertEquals("Setting empty recipients with ext mailer", null, setAndGetExtValues(createFreestyleProjectWithExtMailer(), null));
+		assertEquals("Setting >(disabled)< with ext mailer", "(Disabled)", setAndGetExtValues(createFreestyleProjectWithExtMailer(), "(disabled)"));
 	}
 
 	public void testNormalize() {
@@ -56,9 +62,7 @@ public class EmailSlicerTest extends HudsonTestCase {
 		assertEquals(expect, normalized);
 	}
 
-	public void testSetValues() throws Exception {
-		doTestSetValues("(Disabled)", "");
-		doTestSetValues("(Disabled)", " \b\t ");
+	public void testSetValues() throws Exception {		
 		doTestSetValues("(Disabled)", "(Disabled)");
 		doTestSetValues("caps@gov email@gov.com", "email@gov.com, CAPS@gov");
 	}
@@ -124,6 +128,18 @@ public class EmailSlicerTest extends HudsonTestCase {
 		return got;
 	}
 
+	private String setAndGetExtValues(AbstractProject<?,?> project, String valuesString) {
+		ExtEmailSliceSpec spec = new ExtEmailSliceSpec();
+		
+		List<String> values = new ArrayList<String>();
+		values.add(valuesString);
+		spec.setValues(project, values);
+		
+		List<String> gotList = spec.getValues(project);
+		String got = spec.join(gotList);
+		return got;
+	}
+	
 	private MavenModuleSet createMavenProjectWithSendToIndividualsAndEmptyRecipients()
 			throws IOException {
 		MavenModuleSet mavenProject = createMavenProject();
@@ -141,6 +157,25 @@ public class EmailSlicerTest extends HudsonTestCase {
 		mailer.sendToIndividuals = true;
 		DescribableList<Publisher,Descriptor<Publisher>> publishers = project.getPublishersList();
 		publishers.add(mailer);		
+		return project;
+	}
+	
+	private AbstractProject<?,?> createFreestyleProjectWithExtMailer() throws IOException {
+		FreeStyleProject project = createFreeStyleProject();
+		DescribableList<Publisher,Descriptor<Publisher>> publishers = project.getPublishersList();
+		ExtendedEmailPublisher publisher = new ExtendedEmailPublisher();
+		FailureTrigger trigger = new FailureTrigger();
+		EmailType email = new EmailType();
+		email.setSendToDevelopers(true);
+		email.setSendToRecipientList(true);
+		trigger.setEmail(email);
+		publisher.getConfiguredTriggers().add(trigger);
+		
+		// there is no way to get this text from the plugin itself
+		publisher.defaultContent = "$DEFAULT_CONTENT";
+		publisher.defaultSubject = "$DEFAULT_SUBJECT";
+		
+		publishers.add(publisher);
 		return project;
 	}
 }

--- a/src/test/java/configurationslicing/EmailSlicerTest.java
+++ b/src/test/java/configurationslicing/EmailSlicerTest.java
@@ -1,8 +1,17 @@
 package configurationslicing;
 
 
+import hudson.maven.MavenReporter;
+import hudson.maven.MavenModuleSet;
+import hudson.maven.reporters.MavenMailer;
 import hudson.model.AbstractProject;
+import hudson.model.Descriptor;
+import hudson.model.FreeStyleProject;
+import hudson.tasks.Publisher;
+import hudson.tasks.Mailer;
+import hudson.util.DescribableList;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -10,11 +19,31 @@ import java.util.List;
 import org.jvnet.hudson.test.HudsonTestCase;
 
 import configurationslicing.email.AbstractEmailSliceSpec;
-import configurationslicing.email.ExtEmailSlicer;
 import configurationslicing.email.CoreEmailSlicer.CoreEmailSliceSpec;
+import configurationslicing.email.ExtEmailSlicer;
 import configurationslicing.email.ExtEmailSlicer.ExtEmailSliceSpec;
 
 public class EmailSlicerTest extends HudsonTestCase {
+	
+	/**
+	 * Given a project with a core mailer with mailer.sendToIndividuals == true, setting recipients with a slicer must 
+	 * <ul>
+	 * 	<li>return null when the recipient list is set to empty (null)</li>
+	 *  <li>return "(Disabled)" when the recipient list is set to (disabled) (in any case, even "(dISABLED)")</li>
+	 *  <li>return the set list of recipients (like "john@doe.com sue@gov.com") otherwise</li>
+	 * @throws Exception
+	 */
+	public void testSendToIndividualsWithCoreMailer() throws Exception {
+		assertEquals("Setting empty recipients with sendToIndividuals enabled", null, setAndGetCoreValues(createMavenProjectWithSendToIndividualsAndEmptyRecipients(), null));
+		assertEquals("Setting >(disabled)< with sendToIndividuals enabled", "(Disabled)", setAndGetCoreValues(createMavenProjectWithSendToIndividualsAndEmptyRecipients(), "(disabled)"));
+		assertEquals("Setting >(DISABLED)< with sendToIndividuals enabled", "(Disabled)", setAndGetCoreValues(createMavenProjectWithSendToIndividualsAndEmptyRecipients(), "(DISABLED)"));
+		assertEquals("Setting recipients with sendToIndividuals enabled", "john@doe.com sue@gov.com", setAndGetCoreValues(createMavenProjectWithSendToIndividualsAndEmptyRecipients(), "john@doe.com sue@gov.com"));
+
+		assertEquals("Setting empty recipients with sendToIndividuals enabled", null, setAndGetCoreValues(createFreestyleProjectWithSendToIndividualsAndEmptyRecipients(), null));
+		assertEquals("Setting >(disabled)< with sendToIndividuals enabled", "(Disabled)", setAndGetCoreValues(createFreestyleProjectWithSendToIndividualsAndEmptyRecipients(), "(disabled)"));
+		assertEquals("Setting >(DISABLED)< with sendToIndividuals enabled", "(Disabled)", setAndGetCoreValues(createFreestyleProjectWithSendToIndividualsAndEmptyRecipients(), "(DISABLED)"));
+		assertEquals("Setting recipients with sendToIndividuals enabled", "john@doe.com sue@gov.com", setAndGetCoreValues(createFreestyleProjectWithSendToIndividualsAndEmptyRecipients(), "john@doe.com sue@gov.com"));
+	}
 
 	public void testNormalize() {
 		doTestNormalize("email@gov.com", "email@gov.com");
@@ -82,5 +111,36 @@ public class EmailSlicerTest extends HudsonTestCase {
 		values = slice.getConfiguredValues();
 		assertEquals(4, values.size());
 	}
+
+	private String setAndGetCoreValues(AbstractProject<?,?> project, String valuesString) {
+		CoreEmailSliceSpec spec = new CoreEmailSliceSpec();
+		
+		List<String> values = new ArrayList<String>();
+		values.add(valuesString);
+		spec.setValues(project, values);
+		
+		List<String> gotList = spec.getValues(project);
+		String got = spec.join(gotList);
+		return got;
+	}
+
+	private MavenModuleSet createMavenProjectWithSendToIndividualsAndEmptyRecipients()
+			throws IOException {
+		MavenModuleSet mavenProject = createMavenProject();
+		MavenMailer mailer = new MavenMailer();
+		mailer.sendToIndividuals = true;
+		DescribableList<MavenReporter,Descriptor<MavenReporter>> reporters = mavenProject.getReporters();
+		reporters.add(mailer);		
+		return mavenProject;
+	}
 	
+	private AbstractProject<?,?> createFreestyleProjectWithSendToIndividualsAndEmptyRecipients()
+			throws IOException {
+		FreeStyleProject project = createFreeStyleProject();
+		Mailer mailer = new Mailer();
+		mailer.sendToIndividuals = true;
+		DescribableList<Publisher,Descriptor<Publisher>> publishers = project.getPublishersList();
+		publishers.add(mailer);		
+		return project;
+	}
 }


### PR DESCRIPTION
The configurationslicing plugin now only disables mailers, if
- the recipient list is set to empty, and the notify individuals... checkbox is unchecked.
- the recipient list is explicitly set to "(Disabled)" (case-insensitive) via the configuration slicer.

When setting the recipient list to an empty value via the configuration slicer, email notifications sent to individual developers remain untouched.