### PR TITLE
Add docker config slicing support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,18 @@
             <version>2.7.1</version>
             <optional>true</optional>
         </dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>docker-build-publish</artifactId>
+			<version>1.3.2</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>docker-commons</artifactId>
+			<version>1.5</version>
+			<optional>true</optional>
+		</dependency>
         <dependency>
         	<groupId>org.codehaus.plexus</groupId>
         	<artifactId>plexus-utils</artifactId>

--- a/src/main/java/configurationslicing/docker/AbstractDockerSlicerSpec.java
+++ b/src/main/java/configurationslicing/docker/AbstractDockerSlicerSpec.java
@@ -1,0 +1,177 @@
+package configurationslicing.docker;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.cloudbees.dockerpublish.DockerBuilder;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import configurationslicing.UnorderedStringSlicer.UnorderedStringSlicerSpec;
+import hudson.matrix.MatrixProject;
+import hudson.model.AbstractProject;
+import hudson.model.Descriptor;
+import hudson.model.Project;
+import hudson.tasks.Builder;
+import hudson.util.DescribableList;
+import jenkins.model.Jenkins;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractDockerSlicerSpec
+        extends UnorderedStringSlicerSpec<AbstractProject<?, ?>> {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractDockerSlicerSpec.class);
+
+    private static final String NOTHING = "(Nothing)";
+    static final String DEFAULT = "(Default)";
+
+    public abstract String getName();
+    public abstract String getUrl();
+    public abstract String getSliceParam(DockerBuilder builder);
+    public abstract DockerBuilder setSliceParam(DockerBuilder builder, String value);
+
+    @Override
+    public String getDefaultValueString() {
+        return DEFAULT;
+    }
+
+    @Override
+    public String getName(AbstractProject<?, ?> item) {
+        return item.getDisplayName();
+    }
+
+    public List<AbstractProject<?, ?>> getWorkDomain() {
+        List<AbstractProject<?, ?>> list = new ArrayList<AbstractProject<?, ?>>();
+        List<AbstractProject> temp = Jenkins.getInstance().getAllItems(AbstractProject.class);
+        for (AbstractProject p: temp) {
+            if (p instanceof Project || p instanceof MatrixProject) {
+                list.add(p);
+            }
+        }
+        return list;
+    }
+
+
+    @Override
+    public List<String> getValues(AbstractProject<?,?> item) {
+
+        List<String> valuesList = new ArrayList<String>();
+
+        DescribableList<Builder, Descriptor<Builder>> buildersList = getBuildersList(item);
+        List<DockerBuilder> builders = getDockerBuildersList(buildersList);
+
+        for (DockerBuilder builder: builders) {
+            valuesList.add(getSliceParam(builder));
+        }
+        if (valuesList.isEmpty()) {
+            valuesList.add(NOTHING);
+        }
+
+        return valuesList;
+    }
+
+    @Override
+    public boolean setValues(AbstractProject<?,?> item, List<String> values) {
+
+        DescribableList<Builder, Descriptor<Builder>> buildersList = getBuildersList(item);
+        List<DockerBuilder> dockerBuildersList = getDockerBuildersList(buildersList);
+
+        int maxListSize = Math.max(values.size(), dockerBuildersList.size());
+        DockerBuilder[] oldBuilders = new DockerBuilder[maxListSize];
+        DockerBuilder[] newBuilders = new DockerBuilder[maxListSize];
+
+        for (int i = 0; i < dockerBuildersList.size(); i++) {
+            oldBuilders[i] = dockerBuildersList.get(i);
+        }
+
+        for (int i = 0; i < values.size(); i++) {
+            String value = values.get(i);
+            if(valueIsWritable(value)) {
+                newBuilders[i] = oldBuilders[i];
+                if((oldBuilders[i] != null && !getSliceParam(oldBuilders[i]).equals(value))) {
+                    newBuilders[i] = setSliceParam(newBuilders[i], value);
+                }
+            }
+        }
+
+        // perform any replacements
+        for (int i = 0; i < maxListSize; i++) {
+            if (oldBuilders[i] != null && newBuilders[i] != null && oldBuilders[i] != newBuilders[i]) {
+                replaceBuilder(buildersList, oldBuilders[i], newBuilders[i]);
+            }
+        }
+
+        // add any new ones (can't see when this would happen)
+        for (int i = 0; i < maxListSize; i++) {
+            if (oldBuilders[i] == null && newBuilders[i] != null) {
+                buildersList.add(newBuilders[i]);
+                log.warn(
+                        "added new builder {} to list",
+                        oldBuilders[i].getDescriptor().getDisplayName()
+                );
+            }
+        }
+
+        // delete old ones (this shouldn't happen)
+        for (int i = 0; i < maxListSize; i++) {
+            if (oldBuilders[i] != null && newBuilders[i] == null) {
+                buildersList.remove(oldBuilders[i]);
+                log.error(
+                        "removed builder {} from list",
+                        oldBuilders[i].getDescriptor().getDisplayName()
+                );
+            }
+        }
+
+        return true;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static DescribableList<Builder,Descriptor<Builder>> getBuildersList(
+            AbstractProject<?, ?> item
+    ) {
+        if (item instanceof Project) {
+            return ((Project) item).getBuildersList();
+        } else if (item instanceof MatrixProject) {
+            return ((MatrixProject) item).getBuildersList();
+        } else {
+            return null;
+        }
+
+    }
+
+    private List<DockerBuilder> getDockerBuildersList(
+            DescribableList<Builder, Descriptor<Builder>> builders
+    ) {
+        return builders.getAll(DockerBuilder.class);
+    }
+
+    private boolean valueIsWritable(String value) {
+        return !(value.equals(NOTHING) || value.isEmpty());
+    }
+
+    private void replaceBuilder(
+            DescribableList<Builder,Descriptor<Builder>> builders,
+            Builder oldBuilder,
+            Builder newBuilder
+    ) {
+        List<Builder> newList = Lists.newArrayList(builders.toList());
+        for(int i = 0; i < newList.size(); i++) {
+            Builder builder = newList.get(i);
+            if(builder == oldBuilder) {
+                newList.set(i, newBuilder);
+            }
+        }
+
+        try {
+            builders.replaceBy(newList);
+        } catch (IOException e) {
+            log.error(
+                    "Failed to replace builder {} in list",
+                    oldBuilder.getDescriptor().getDisplayName()
+            );
+            Throwables.propagate(e);
+        }
+    }
+}

--- a/src/main/java/configurationslicing/docker/DockerFilePathSlicer.java
+++ b/src/main/java/configurationslicing/docker/DockerFilePathSlicer.java
@@ -1,0 +1,46 @@
+package configurationslicing.docker;
+
+import com.cloudbees.dockerpublish.DockerBuilder;
+import configurationslicing.UnorderedStringSlicer;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+
+@Extension
+public class DockerFilePathSlicer extends UnorderedStringSlicer<AbstractProject<?,?>> {
+
+    public DockerFilePathSlicer() {super (new DockerSlicerSpec()); }
+
+    public static class DockerSlicerSpec extends
+            AbstractDockerSlicerSpec {
+
+        @Override
+        public String getName() {
+            return "Docker Slicer - Dockerfile Path";
+        }
+
+        @Override
+        public String getUrl() {
+            return "dockerfilepath";
+        }
+
+        @Override
+        public String getSliceParam(DockerBuilder builder) {
+            if (builder.getDockerfilePath() == null || builder.getDockerfilePath().isEmpty()) {
+                return DEFAULT;
+            } else {
+                return builder.getDockerfilePath();
+            }
+        }
+
+        @Override
+        public DockerBuilder setSliceParam(DockerBuilder builder, String value) {
+            if (!value.equals(DEFAULT)) {
+                builder.setDockerfilePath(value);
+            } else {
+                builder.setDockerfilePath(null);
+            }
+            return builder;
+        }
+
+    }
+}

--- a/src/main/java/configurationslicing/docker/DockerRegistryURLSlicer.java
+++ b/src/main/java/configurationslicing/docker/DockerRegistryURLSlicer.java
@@ -1,0 +1,44 @@
+package configurationslicing.docker;
+
+import com.cloudbees.dockerpublish.DockerBuilder;
+import configurationslicing.UnorderedStringSlicer;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
+
+@Extension
+public class DockerRegistryURLSlicer extends UnorderedStringSlicer<AbstractProject<?,?>> {
+
+    public DockerRegistryURLSlicer() {super (new DockerSlicerSpec()); }
+
+    public static class DockerSlicerSpec extends
+            AbstractDockerSlicerSpec {
+
+        @Override
+        public String getName() {
+            return "Docker Slicer - Registry URL";
+        }
+
+        @Override
+        public String getUrl() {
+            return "dockerregistryurl";
+        }
+
+        @Override
+        public String getSliceParam(DockerBuilder builder) {
+            return builder.getRegistry().getUrl();
+        }
+
+        @Override
+        public DockerBuilder setSliceParam(DockerBuilder builder, String value) {
+            DockerRegistryEndpoint dockerRegistry = new DockerRegistryEndpoint(
+                    value,
+                    builder.getRegistry().getCredentialsId()
+            );
+
+            builder.setRegistry(dockerRegistry);
+            return builder;
+        }
+
+    }
+}

--- a/src/main/java/configurationslicing/docker/DockerRepoNameSlicer.java
+++ b/src/main/java/configurationslicing/docker/DockerRepoNameSlicer.java
@@ -1,0 +1,64 @@
+package configurationslicing.docker;
+
+import com.cloudbees.dockerpublish.DockerBuilder;
+import configurationslicing.UnorderedStringSlicer;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+
+
+@Extension
+public class DockerRepoNameSlicer extends UnorderedStringSlicer<AbstractProject<?,?>> {
+
+    public DockerRepoNameSlicer() {super (new DockerSlicerSpec()); }
+
+    public static class DockerSlicerSpec extends
+            AbstractDockerSlicerSpec {
+
+        @Override
+        public String getName() {
+            return "Docker Slicer - Repo Name";
+        }
+
+        @Override
+        public String getUrl() {
+            return "dockerreponame";
+        }
+
+        @Override
+        public String getSliceParam(DockerBuilder builder) {
+            return builder.getRepoName();
+        }
+
+        @Override
+        public DockerBuilder setSliceParam(DockerBuilder builder, String value) {
+            // setting repo name isn't exposed by the api so we're copying the current one and
+            // replacing the repo name using the constructor
+            return setRepoName(builder, value);
+        }
+
+        private DockerBuilder setRepoName(DockerBuilder oldBuilder, String repoName) {
+
+            DockerBuilder newBuilder = new DockerBuilder(repoName);
+
+            newBuilder.setBuildAdditionalArgs(oldBuilder.getBuildAdditionalArgs());
+            newBuilder.setBuildContext(oldBuilder.getBuildContext());
+            newBuilder.setCreateFingerprint(oldBuilder.isCreateFingerprint());
+            newBuilder.setDockerfilePath(oldBuilder.getDockerfilePath());
+            newBuilder.setDockerToolName(oldBuilder.getDockerToolName());
+            newBuilder.setForcePull(oldBuilder.isForcePull());
+            newBuilder.setForceTag(oldBuilder.isForceTag());
+            newBuilder.setNoCache(oldBuilder.isNoCache());
+            newBuilder.setRepoTag(oldBuilder.getRepoTag());
+            newBuilder.setRegistry(oldBuilder.getRegistry());
+            newBuilder.setServer(oldBuilder.getServer());
+            newBuilder.setSkipBuild(oldBuilder.isSkipBuild());
+            newBuilder.setSkipDecorate(oldBuilder.isSkipDecorate());
+            newBuilder.setSkipPush(oldBuilder.isSkipPush());
+            newBuilder.setSkipTagLatest(oldBuilder.isSkipTagLatest());
+
+            return newBuilder;
+
+        }
+
+    }
+}

--- a/src/main/java/configurationslicing/docker/DockerRepoTagSlicer.java
+++ b/src/main/java/configurationslicing/docker/DockerRepoTagSlicer.java
@@ -1,0 +1,39 @@
+package configurationslicing.docker;
+
+import com.cloudbees.dockerpublish.DockerBuilder;
+import configurationslicing.UnorderedStringSlicer;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+
+
+@Extension
+public class DockerRepoTagSlicer extends UnorderedStringSlicer<AbstractProject<?,?>> {
+
+    public DockerRepoTagSlicer() {super (new DockerSlicerSpec()); }
+
+    public static class DockerSlicerSpec extends
+            AbstractDockerSlicerSpec {
+
+        @Override
+        public String getName() {
+            return "Docker Slicer - Repo Tags";
+        }
+
+        @Override
+        public String getUrl() {
+            return "dockerrepotags";
+        }
+
+        @Override
+        public String getSliceParam(DockerBuilder builder) {
+            return builder.getRepoTag();
+        }
+
+        @Override
+        public DockerBuilder setSliceParam(DockerBuilder builder, String value) {
+            builder.setRepoTag(value);
+            return builder;
+        }
+
+    }
+}

--- a/src/test/java/configurationslicing/DockerSlicerTest.java
+++ b/src/test/java/configurationslicing/DockerSlicerTest.java
@@ -1,0 +1,100 @@
+package configurationslicing;
+
+import java.util.List;
+
+import com.cloudbees.dockerpublish.DockerBuilder;
+import com.google.common.collect.Lists;
+import configurationslicing.docker.DockerFilePathSlicer;
+import configurationslicing.docker.DockerRegistryURLSlicer;
+import configurationslicing.docker.DockerRepoNameSlicer;
+import configurationslicing.docker.DockerRepoTagSlicer;
+import hudson.model.Project;
+import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+public class DockerSlicerTest extends HudsonTestCase {
+
+    private String dockerfilePath = "test/file/path/";
+    private String registryUrl = "test/url";
+    private String credentials = "credId";
+    private DockerRegistryEndpoint dockerRegistry = new DockerRegistryEndpoint(registryUrl, credentials);
+    private String repoName = "testRepoName";
+    private String repoTag = "testRepoTag";
+
+    @SuppressWarnings("unchecked")
+    public void testSetDockerfilePath() throws Exception {
+        DockerFilePathSlicer.DockerSlicerSpec spec = new DockerFilePathSlicer.DockerSlicerSpec();
+        Project project = createProject();
+        String updatedFilePath = "new/file/path";
+
+        assertEquals(Lists.newArrayList(dockerfilePath), spec.getValues(project));
+
+        spec.setValues(project, Lists.newArrayList(updatedFilePath));
+
+        List<String> values = spec.getValues(project);
+        assert(values.contains(updatedFilePath));
+        assert(!values.contains(dockerfilePath));
+
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSetRegistryUrl() throws Exception {
+        DockerRegistryURLSlicer.DockerSlicerSpec spec = new DockerRegistryURLSlicer.DockerSlicerSpec();
+        Project project = createProject();
+        String updatedRegistryUrl = "new/url";
+
+        assertEquals(Lists.newArrayList(dockerRegistry.getUrl()), spec.getValues(project));
+
+        spec.setValues(project, Lists.newArrayList(updatedRegistryUrl));
+
+        List<String> values = spec.getValues(project);
+        assert(values.contains(updatedRegistryUrl));
+        assert(!values.contains(registryUrl));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSetRepoName() throws Exception {
+        DockerRepoNameSlicer.DockerSlicerSpec spec = new DockerRepoNameSlicer.DockerSlicerSpec();
+        Project project = createProject();
+        String updatedRepoName = "newRepoName";
+
+        assertEquals(Lists.newArrayList(repoName), spec.getValues(project));
+
+        spec.setValues(project, Lists.newArrayList(updatedRepoName));
+
+        List<String> values = spec.getValues(project);
+        assert(values.contains(updatedRepoName));
+        assert(!values.contains(repoName));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSetRepoTag() throws Exception {
+        DockerRepoTagSlicer.DockerSlicerSpec spec = new DockerRepoTagSlicer.DockerSlicerSpec();
+        Project project = createProject();
+        String updatedRepoTag = "newRepoTag";
+
+        assertEquals(Lists.newArrayList(repoTag), spec.getValues(project));
+
+        spec.setValues(project, Lists.newArrayList(updatedRepoTag));
+
+        List<String> values = spec.getValues(project);
+        assert(values.contains(updatedRepoTag));
+        assert(!values.contains(repoTag));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Project createProject() throws Exception {
+        Project project = createFreeStyleProject();
+        project.getBuildersList().add(getDockerBuilder());
+        return project;
+    }
+
+    private DockerBuilder getDockerBuilder() {
+        DockerBuilder dockerBuilder = new DockerBuilder(repoName);
+        dockerBuilder.setDockerfilePath(dockerfilePath);
+        dockerBuilder.setRegistry(dockerRegistry);
+        dockerBuilder.setRepoTag(repoTag);
+
+        return dockerBuilder;
+    }
+}


### PR DESCRIPTION
This add support to slice docker configs across multiple projects.
Supported configs are:
* Dockerfile Path
* Repo Name
* Repo Tags
* Registry URL