### PR TITLE
move Configuration Slicing into the "Tools and Actions" category

### DIFF
--- a/src/main/java/configurationslicing/ConfigurationSlicing.java
+++ b/src/main/java/configurationslicing/ConfigurationSlicing.java
@@ -46,6 +46,10 @@ public class ConfigurationSlicing extends ManagementLink {
         return "Configuration Slicing";
     }
 
+    public String getCategoryName() {
+        return "TOOLS";
+    }
+
     @SuppressWarnings("unchecked")
 	public List<Slicer> getAxes() {
     	ExtensionList<Slicer> elist = Jenkins.getInstance().getExtensionList(Slicer.class);


### PR DESCRIPTION
For Jenkins 2.226+, move the "Configuration Slicing" management link into the "Tools and Actions" category.

See jenkinsci/jenkins#4546 for details about this new categories system.

See jenkinsci/configuration-as-code-plugin#1357, or jenkinsci/credentials-plugin#139 + jenkinsci/credentials-plugin#140 for examples of how it has been implemented in other plugins.

Note that implementing this does not require bumping jenkins core dependency to a recent version, so the change proposed here is really minimal.