### PR TITLE
chore: Prepare for sunset icon removal from core

### DIFF
--- a/src/main/resources/configurationslicing/ConfigurationSlicing/SliceExecutor/sidepanel-executor.jelly
+++ b/src/main/resources/configurationslicing/ConfigurationSlicing/SliceExecutor/sidepanel-executor.jelly
@@ -1,17 +1,17 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
   <l:header />
   <l:side-panel>
     <l:tasks>
-     <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}" />
+     <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}" />
      <l:isAdmin>
-       <l:task icon="images/24x24/setting.gif" href="${rootURL}/manage" title="${%Manage Jenkins}" />
-	   <l:task icon="images/24x24/orange-square.gif" href="${rootURL}/${it.parent.urlName}" title="${it.parent.displayName}" />
-	   <l:task icon="images/24x24/orange-square.gif" href="${rootURL}/${it.parent.urlName}/${it.slicer.url}" title="${it.slicer.name}" />
-	   <l:task icon="images/24x24/folder.gif" title="${%Configuration by View}" />
+       <l:task icon="icon-setting icon-md" href="${rootURL}/manage" title="${%Manage Jenkins}" />
+	   <l:task icon="icon-orange-square icon-md" href="${rootURL}/${it.parent.urlName}" title="${it.parent.displayName}" />
+	   <l:task icon="icon-orange-square icon-md" href="${rootURL}/${it.parent.urlName}/${it.slicer.url}" title="${it.slicer.name}" />
+	   <l:task icon="icon-folder icon-md" title="${%Configuration by View}" />
 	   <l:tasks>
 	   <j:forEach var="view" items="${it.parent.views}">
-	   		<l:task icon="images/24x24/folder.gif" href="${rootURL}/${it.parent.urlName}/${it.slicer.url}/view?view=${view}" title="${view}" />
+	   		<l:task icon="icon-folder icon-md" href="${rootURL}/${it.parent.urlName}/${it.slicer.url}/view?view=${view}" title="${view}" />
 	   </j:forEach>
 	   </l:tasks>
      </l:isAdmin>

--- a/src/main/resources/configurationslicing/ConfigurationSlicing/sidepanel.jelly
+++ b/src/main/resources/configurationslicing/ConfigurationSlicing/sidepanel.jelly
@@ -1,12 +1,12 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
   <l:header />
   <l:side-panel>
     <l:tasks>
-     <l:task icon="images/24x24/up.png" href="${rootURL}/" title="${%Back to Dashboard}" />
+     <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}" />
      <l:isAdmin>
-       <l:task icon="images/24x24/setting.png" href="${rootURL}/manage" title="${%Manage Jenkins}" />
-	   <l:task icon="images/24x24/orange-square.png" href="${rootURL}/${it.urlName}" title="${it.displayName}" />
+       <l:task icon="icon-setting icon-md" href="${rootURL}/manage" title="${%Manage Jenkins}" />
+	   <l:task icon="icon-orange-square icon-md" href="${rootURL}/${it.urlName}" title="${it.displayName}" />
      </l:isAdmin>
     </l:tasks>
   </l:side-panel>


### PR DESCRIPTION
Preparation for core sunsetting dated icons: `https://github.com/jenkinsci/jenkins/pull/5778`

@guysoft Would be nice if you can also trigger a release after merging this PR. The core PR is blocked until then.
Thanks in advance!