### PR TITLE
[JENKINS-48738] Fix NPE when setting JDK

### DIFF
--- a/src/main/java/configurationslicing/jdk/JdkSlicer.java
+++ b/src/main/java/configurationslicing/jdk/JdkSlicer.java
@@ -64,7 +64,9 @@ public class JdkSlicer extends UnorderedStringSlicer<AbstractProject> {
             JDK oldJdk = item.getJDK();
             if (!equals(oldJdk, jdk)) {
 	            try {
-	                item.setJDK(jdk);
+	                if (jdk != null) {
+                            item.setJDK(jdk);
+                        }
 	                return true;
 	            } catch (IOException e) {
 	                e.printStackTrace();


### PR DESCRIPTION
## Fix null pointer exception when setting JDK

See the original proposed change at https://github.com/jenkinsci/configurationslicing-plugin/pull/22/commits/a15d15ae0e3a666d30acf88f2156875d867e977e

Confirmed with interactive testing that the null pointer exception is resolved and that the configuration slicing plugin can change the value of the JDK that is defined on a Freestyle job.  I changed between jdk-8 and jdk-20.

The plugin cannot reset the definition of the JDK to the default because that causes a null pointer exception in AbstractProject as reported by the original bug report [JENKINS-48738](https://issues.jenkins.io/browse/JENKINS-48738)

Avoid the null pointer exception by ignoring the attempt to reset the JDK value to default.

Thanks to @Evildethow and @ahertier for implementation

### Testing done

Interactive testing of freestyle project with Jenkins 2.401.  I configured two JDK tool values, jdk-8 and jdk-20, then assigned one of the values to the job. The configuration slicing plugin with this change is able to change the configuration from jdk-8 to jdk-20 and from jdk-20 to jdk-8.  The attempt to change JDK to an empty string is sliently ignored rather than generating a null pointer exception.

AbstractProject does not seem to have a method that will allow the JDK of a project to be reset to the default value.  The user interface is able to make that change, but apparently it makes the change without passing a `null` to `setJDK()`.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
