### PR TITLE
Require Jenkins 2.401.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/configurationslicing-plugin</gitHubRepo>
-        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins.version>2.401.3</jenkins.version>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>2543.vfb_1a_5fb_9496d</version>
+                <artifactId>bom-2.401.x</artifactId>
+                <version>2675.v1515e14da_7a_6</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
78% of the 2100 installations of the most recent release are using
2.401.3 or newer already.  Jenkins 2.401.2 and earlier have known
unresolved security vulnerabilities.  The most recent release was 8
months ago.

Users that are upgrading (approximately 20% of all installations of
the plugin are on the most recent release), are using newer Jenkins
versions.  This will allow the build-timeout plugin dependency to be
updated as well.
