### PR TITLE
Remove usages of deprecated `ANTLRException`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/configurationslicing-plugin</gitHubRepo>
-        <jenkins.version>2.401.3</jenkins.version>
+        <jenkins.version>2.426.3</jenkins.version>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.401.x</artifactId>
-                <version>2745.vc7b_fe4c876fa_</version>
+                <artifactId>bom-2.426.x</artifactId>
+                <version>2839.v003b_4d9d24fd</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/configurationslicing/timer/AbstractTimerSliceSpec.java
+++ b/src/main/java/configurationslicing/timer/AbstractTimerSliceSpec.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import antlr.ANTLRException;
 import configurationslicing.TopLevelItemSelector;
 import configurationslicing.UnorderedStringSlicer.UnorderedStringSlicerSpec;
 
@@ -54,7 +53,7 @@ public abstract class AbstractTimerSliceSpec extends
 		return TopLevelItemSelector.getAllTopLevelItems(Job.class);
 	}
 
-	public abstract Trigger newTrigger(String spec, Trigger oldTrigger) throws ANTLRException;
+	public abstract Trigger newTrigger(String spec, Trigger oldTrigger);
 
 	public boolean setValues(Job item, List<String> set) {
 		if (set.isEmpty())
@@ -90,7 +89,7 @@ public abstract class AbstractTimerSliceSpec extends
 				newtrigger.start(item, true);
 			}
 			return true;
-		} catch (ANTLRException e) {
+		} catch (IllegalArgumentException e) {
 			// need to log this
 			return false;
 		} catch (IOException e) {

--- a/src/main/java/configurationslicing/timer/SCMTimerSliceStringSlicer.java
+++ b/src/main/java/configurationslicing/timer/SCMTimerSliceStringSlicer.java
@@ -5,7 +5,6 @@ import hudson.model.AbstractProject;
 import hudson.model.Job;
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.Trigger;
-import antlr.ANTLRException;
 import configurationslicing.UnorderedStringSlicer;
 
 @Extension
@@ -29,7 +28,7 @@ public class SCMTimerSliceStringSlicer extends UnorderedStringSlicer<Job>{
         }
         
         @SuppressWarnings("unchecked")
-        public Trigger newTrigger(String spec, Trigger oldTrigger) throws ANTLRException {
+        public Trigger newTrigger(String spec, Trigger oldTrigger) {
             boolean ignorePostCommitHooks = false;
             if(oldTrigger instanceof SCMTrigger) {
                 ignorePostCommitHooks = ((SCMTrigger)oldTrigger).isIgnorePostCommitHooks();

--- a/src/main/java/configurationslicing/timer/TimerSliceStringSlicer.java
+++ b/src/main/java/configurationslicing/timer/TimerSliceStringSlicer.java
@@ -5,7 +5,6 @@ import hudson.model.AbstractProject;
 import hudson.model.Job;
 import hudson.triggers.TimerTrigger;
 import hudson.triggers.Trigger;
-import antlr.ANTLRException;
 import configurationslicing.UnorderedStringSlicer;
 
 @Extension
@@ -29,7 +28,7 @@ public class TimerSliceStringSlicer extends UnorderedStringSlicer<Job>{
         }
 
         @SuppressWarnings("unchecked")
-		public Trigger newTrigger(String spec, Trigger oldTrigger) throws ANTLRException {
+		public Trigger newTrigger(String spec, Trigger oldTrigger) {
             return new TimerTrigger(spec);
         }
         


### PR DESCRIPTION
In recent versions of core, catching `IllegalArgumentException` is preferred to minimize API exposure of ANTLR.