### PR TITLE
Fix matrix configuration filtering in build command slicers

### DIFF
--- a/src/main/java/configurationslicing/executeshell/AbstractBuildCommandSlicer.java
+++ b/src/main/java/configurationslicing/executeshell/AbstractBuildCommandSlicer.java
@@ -1,6 +1,7 @@
 package configurationslicing.executeshell;
 
 import configurationslicing.UnorderedStringSlicer;
+import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.MatrixProject;
 import hudson.model.AbstractProject;
 import hudson.model.Descriptor;
@@ -66,6 +67,9 @@ public abstract class AbstractBuildCommandSlicer<B extends Builder> extends Unor
             List<AbstractProject> list = new ArrayList<AbstractProject>();
             List<AbstractProject> temp = Jenkins.get().getAllItems(AbstractProject.class);
             for (AbstractProject p : temp) {
+                if (p instanceof MatrixConfiguration) {
+                    continue;
+                }
                 if (p instanceof Project || p instanceof MatrixProject) {
                     list.add(p);
                 }

--- a/src/test/java/configurationslicing/ShellTest.java
+++ b/src/test/java/configurationslicing/ShellTest.java
@@ -1,8 +1,13 @@
 package configurationslicing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import configurationslicing.executeshell.ExecuteShellSlicer;
+import hudson.matrix.Axis;
+import hudson.matrix.AxisList;
+import hudson.matrix.MatrixConfiguration;
+import hudson.matrix.MatrixProject;
 import hudson.model.Project;
 import hudson.tasks.Shell;
 import java.util.ArrayList;
@@ -48,6 +53,21 @@ class ShellTest {
         doTestSetMultipleShells("shell-" + (count++), new String[] {"a", "b", "c"}, new String[] {"", "d", "", "e"});
         doTestSetMultipleShells("shell-" + (count++), new String[] {"a", "b", "c"}, new String[] {"c", "b", "a"});
         doTestSetMultipleShells("shell-" + (count++), new String[] {}, new String[] {"a", "b"});
+    }
+
+    @Test
+    void testGetWorkDomainExcludesMatrixConfigurations() throws Exception {
+        ExecuteShellSlicer.ExecuteShellSliceSpec spec = new ExecuteShellSlicer.ExecuteShellSliceSpec();
+        MatrixProject matrixProject = r.createProject(MatrixProject.class, "matrix-project");
+        matrixProject.setAxes(new AxisList(new Axis("environment", "development", "production")));
+        matrixProject.getBuildersList().add(new Shell("echo matrix"));
+
+        List<?> workDomain = spec.getWorkDomain();
+
+        assertEquals(2, matrixProject.getItems().size());
+        assertEquals(1, workDomain.size());
+        assertEquals(matrixProject, workDomain.get(0));
+        assertFalse(workDomain.stream().anyMatch(MatrixConfiguration.class::isInstance));
     }
 
     public void doTestSetMultipleShells(String name, String[] oldCommands, String[] newCommands) throws Exception {


### PR DESCRIPTION
  Fixes #355

  - Exclude `MatrixConfiguration` children from build command slicer work domains.
  - Add a JenkinsRule regression test that preserves the parent `MatrixProject`.

  Tests:
  - `mvn -Dtest=ShellTest test`
